### PR TITLE
Add a block for daily pokes

### DIFF
--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -47,18 +47,17 @@ contract PokingAddresses {
 }
 
 contract MegaPoker is PokingAddresses {
+
+    uint256 public lastPoke;
+
     function poke() external {
         bool ok;
 
         // poke() = 0x18178358
         (ok,) = eth.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = bat.call(abi.encodeWithSelector(0x18178358));
         (ok,) = btc.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = zrx.call(abi.encodeWithSelector(0x18178358));
         (ok,) = mana.call(abi.encodeWithSelector(0x18178358));
         (ok,) = comp.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = link.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = lrc.call(abi.encodeWithSelector(0x18178358));
         (ok,) = yfi.call(abi.encodeWithSelector(0x18178358));
         (ok,) = bal.call(abi.encodeWithSelector(0x18178358));
         (ok,) = uni.call(abi.encodeWithSelector(0x18178358));
@@ -73,17 +72,13 @@ contract MegaPoker is PokingAddresses {
         (ok,) = univ2aaveeth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = matic.call(abi.encodeWithSelector(0x18178358));
         (ok,) = wsteth.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = guniv3daiusdc1.call(abi.encodeWithSelector(0x18178358));
+
 
         // poke(bytes32) = 0x1504460f
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("BAT-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WBTC-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ZRX-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("MANA-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("COMP-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LINK-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LRC-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("YFI-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("BAL-A")));
@@ -101,6 +96,24 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-C")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("MATIC-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
+
+
+        // Daily pokes
+        //  Reduced cost pokes
+        if (lastPoke <= block.timestamp - 1 days) {
+            (ok,) = bat.call(abi.encodeWithSelector(0x18178358));
+            (ok,) = zrx.call(abi.encodeWithSelector(0x18178358));
+            (ok,) = link.call(abi.encodeWithSelector(0x18178358));
+            (ok,) = lrc.call(abi.encodeWithSelector(0x18178358));
+            (ok,) = guniv3daiusdc1.call(abi.encodeWithSelector(0x18178358));
+
+            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("BAT-A")));
+            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ZRX-A")));
+            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LINK-A")));
+            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LRC-A")));
+            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
+        }
+
+        lastPoke = block.timestamp;
     }
 }

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -48,7 +48,7 @@ contract PokingAddresses {
 
 contract MegaPoker is PokingAddresses {
 
-    uint256 public lastPoke;
+    uint256 public last;
 
     function poke() external {
         bool ok;
@@ -100,7 +100,7 @@ contract MegaPoker is PokingAddresses {
 
         // Daily pokes
         //  Reduced cost pokes
-        if (lastPoke <= block.timestamp - 1 days) {
+        if (last <= block.timestamp - 1 days) {
             (ok,) = bat.call(abi.encodeWithSelector(0x18178358));
             (ok,) = zrx.call(abi.encodeWithSelector(0x18178358));
             (ok,) = link.call(abi.encodeWithSelector(0x18178358));
@@ -112,8 +112,8 @@ contract MegaPoker is PokingAddresses {
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LINK-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LRC-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
-        }
 
-        lastPoke = block.timestamp;
+            last = block.timestamp;
+        }
     }
 }

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -217,13 +217,9 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         hackedValue = 0x0000000000000000000000000000000000000000000000000000000000000123;
 
         assertTrue(OsmLike(eth).read() != hackedValue);
-        assertTrue(OsmLike(bat).read() != hackedValue);
         assertTrue(OsmLike(btc).read() != hackedValue);
-        assertTrue(OsmLike(zrx).read() != hackedValue);
         assertTrue(OsmLike(mana).read() != hackedValue);
         assertTrue(OsmLike(comp).read() != hackedValue);
-        assertTrue(OsmLike(link).read() != hackedValue);
-        assertTrue(OsmLike(lrc).read() != hackedValue);
         assertTrue(OsmLike(yfi).read() != hackedValue);
         assertTrue(OsmLike(bal).read() != hackedValue);
         assertTrue(OsmLike(uni).read() != hackedValue);
@@ -238,9 +234,14 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(univ2aaveeth).read() != hackedValue);
         assertTrue(OsmLike(matic).read() != hackedValue);
         assertTrue(OsmLike(wsteth).read() != hackedValue);
+
+        assertTrue(OsmLike(bat).read() != hackedValue);
+        assertTrue(OsmLike(link).read() != hackedValue);
+        assertTrue(OsmLike(zrx).read() != hackedValue);
+        assertTrue(OsmLike(lrc).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
 
-        hevm.warp(block.timestamp + 1 hours);
+        hevm.warp(block.timestamp + 1 days);
         megaPoker.poke();
 
         assertEq(OsmLike(eth).read(), hackedValue);

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -245,13 +245,9 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         megaPoker.poke();
 
         assertEq(OsmLike(eth).read(), hackedValue);
-        assertEq(OsmLike(bat).read(), hackedValue);
         assertEq(OsmLike(btc).read(), hackedValue);
-        assertEq(OsmLike(zrx).read(), hackedValue);
         assertEq(OsmLike(mana).read(), hackedValue);
         assertEq(OsmLike(comp).read(), hackedValue);
-        assertEq(OsmLike(link).read(), hackedValue);
-        assertEq(OsmLike(lrc).read(), hackedValue);
         assertEq(OsmLike(yfi).read(), hackedValue);
         assertEq(OsmLike(bal).read(), hackedValue);
         assertEq(OsmLike(uni).read(), hackedValue);
@@ -266,6 +262,11 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(univ2aaveeth).read(), hackedValue);
         assertEq(OsmLike(matic).read(), hackedValue);
         assertEq(OsmLike(wsteth).read(), hackedValue);
+
+        assertEq(OsmLike(bat).read(), hackedValue);
+        assertEq(OsmLike(link).read(), hackedValue);
+        assertEq(OsmLike(zrx).read(), hackedValue);
+        assertEq(OsmLike(lrc).read(), hackedValue);
         assertEq(OsmLike(guniv3daiusdc1).read(), hackedValue);
 
         uint256 mat;


### PR DESCRIPTION
Alternative to https://github.com/makerdao/megapoker/pull/24

Adds a `lastPoke` variable that tracks the timestamp of the last poke timestamp. If the last poke was over a day ago, call a subset of collateral types. (currently `ZRX`, `LINK`, `BAT`, `LRC`, and `GUNIV3`

This pattern is extensible to pokes on other intervals as well.