### PR TITLE
Offboarding: bat, zrx, comp, lrc, bal, aave, univ2linketh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker curent Mainnet Address: [0x73eb5c8a7d02ae25f61b3bf7e0502261dbb8632a](https://etherscan.io/address/0x73eb5c8a7d02ae25f61b3bf7e0502261dbb8632a#code)
+MegaPoker curent Mainnet Address: [0x8e01D186594983943A614cC724bD1d6F8bFdd41B](https://etherscan.io/address/0x8e01D186594983943A614cC724bD1d6F8bFdd41B#code)
 
 # OmegaPoker
 

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -21,22 +21,15 @@ pragma solidity ^0.6.12;
 contract PokingAddresses {
     // OSMs and Spotter addresses
     address constant eth            = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763;
-    address constant bat            = 0xB4eb54AF9Cc7882DF0121d26c5b97E802915ABe6;
     address constant btc            = 0xf185d0682d50819263941e5f4EacC763CC5C6C42;
-    address constant zrx            = 0x7382c066801E7Acb2299aC8562847B9883f5CD3c;
     address constant mana           = 0x8067259EA630601f319FccE477977E55C6078C13;
-    address constant comp           = 0xBED0879953E633135a48a157718Aa791AC0108E4;
     address constant link           = 0x9B0C694C6939b5EA9584e9b61C7815E8d97D9cC7;
-    address constant lrc            = 0x9eb923339c24c40Bef2f4AF4961742AA7C23EF3a;
     address constant yfi            = 0x5F122465bCf86F45922036970Be6DD7F58820214;
-    address constant bal            = 0x3ff860c0F28D69F392543A16A397D0dAe85D16dE;
     address constant uni            = 0xf363c7e351C96b910b92b45d34190650df4aE8e7;
-    address constant aave           = 0x8Df8f06DC2dE0434db40dcBb32a82A104218754c;
     address constant univ2daieth    = 0xFc8137E1a45BAF0030563EC4F0F851bd36a85b7D;
     address constant univ2wbtceth   = 0x8400D2EDb8B97f780356Ef602b1BdBc082c2aD07;
     address constant univ2usdceth   = 0xf751f24DD9cfAd885984D1bA68860F558D21E52A;
     address constant univ2daiusdc   = 0x25D03C2C928ADE19ff9f4FFECc07d991d0df054B;
-    address constant univ2linketh   = 0xd7d31e62AE5bfC3bfaa24Eda33e8c32D31a1746F;
     address constant univ2unieth    = 0x8462A88f50122782Cc96108F476deDB12248f931;
     address constant univ2wbtcdai   = 0x5bB72127a196392cf4aC00Cf57aB278394d24e55;
     address constant matic          = 0x8874964279302e6d4e523Fb1789981C39a1034Ba;
@@ -57,11 +50,9 @@ contract MegaPoker is PokingAddresses {
         (ok,) = eth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = btc.call(abi.encodeWithSelector(0x18178358));
         (ok,) = mana.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = comp.call(abi.encodeWithSelector(0x18178358));
         (ok,) = link.call(abi.encodeWithSelector(0x18178358));
         (ok,) = yfi.call(abi.encodeWithSelector(0x18178358));
         (ok,) = uni.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = aave.call(abi.encodeWithSelector(0x18178358));
         (ok,) = univ2daieth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = univ2wbtceth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = univ2usdceth.call(abi.encodeWithSelector(0x18178358));
@@ -76,13 +67,11 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WBTC-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("MANA-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("COMP-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LINK-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("YFI-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("RENBTC-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNI-A")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("AAVE-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2DAIETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2WBTCETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2USDCETH-A")));
@@ -99,22 +88,13 @@ contract MegaPoker is PokingAddresses {
         // Daily pokes
         //  Reduced cost pokes
         if (last <= block.timestamp - 1 days) {
-            (ok,) = bat.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = zrx.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = lrc.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = bal.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = univ2linketh.call(abi.encodeWithSelector(0x18178358));
+
             // The GUINIV3DAIUSDCX Oracles are very expensive to poke, and the price should not
             //  change frequently, so they are getting poked only once a day.
             (ok,) = guniv3daiusdc1.call(abi.encodeWithSelector(0x18178358));
             (ok,) = guniv3daiusdc2.call(abi.encodeWithSelector(0x18178358));
 
 
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("BAT-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ZRX-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LRC-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("BAL-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2LINKETH-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC2-A")));
 

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -167,22 +167,15 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         // Hacking nxt price to 0x123 (and making it valid)
         bytes32 hackedValue = 0x0000000000000000000000000000000100000000000000000000000000000123;
         hevm.store(eth, bytes32(uint256(4)), hackedValue);
-        hevm.store(bat, bytes32(uint256(4)), hackedValue);
         hevm.store(btc, bytes32(uint256(4)), hackedValue);
-        hevm.store(zrx, bytes32(uint256(4)), hackedValue);
         hevm.store(mana, bytes32(uint256(4)), hackedValue);
-        hevm.store(comp, bytes32(uint256(4)), hackedValue);
         hevm.store(link, bytes32(uint256(4)), hackedValue);
-        hevm.store(lrc, bytes32(uint256(4)), hackedValue);
         hevm.store(yfi, bytes32(uint256(4)), hackedValue);
-        hevm.store(bal, bytes32(uint256(4)), hackedValue);
         hevm.store(uni, bytes32(uint256(4)), hackedValue);
-        hevm.store(aave, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2daieth, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2wbtceth, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2usdceth, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2daiusdc, bytes32(uint256(4)), hackedValue);
-        hevm.store(univ2linketh, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2unieth, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2wbtcdai, bytes32(uint256(4)), hackedValue);
         hevm.store(matic, bytes32(uint256(4)), hackedValue);
@@ -192,22 +185,15 @@ contract MegaPokerTest is DSTest, PokingAddresses {
 
         // Whitelisting tester address
         hevm.store(eth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(bat, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(btc, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(zrx, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(mana, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(comp, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(link, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(lrc, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(yfi, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(bal, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(uni, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(aave, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(univ2daieth, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(univ2wbtceth, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(univ2usdceth, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(univ2daiusdc, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
-        hevm.store(univ2linketh, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(univ2unieth, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(univ2wbtcdai, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(matic, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
@@ -221,12 +207,9 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(eth).read() != hackedValue);
         assertTrue(OsmLike(btc).read() != hackedValue);
         assertTrue(OsmLike(mana).read() != hackedValue);
-        assertTrue(OsmLike(comp).read() != hackedValue);
         assertTrue(OsmLike(link).read() != hackedValue);
         assertTrue(OsmLike(yfi).read() != hackedValue);
-        assertTrue(OsmLike(bal).read() != hackedValue);
         assertTrue(OsmLike(uni).read() != hackedValue);
-        assertTrue(OsmLike(aave).read() != hackedValue);
         assertTrue(OsmLike(univ2daieth).read() != hackedValue);
         assertTrue(OsmLike(univ2wbtceth).read() != hackedValue);
         assertTrue(OsmLike(univ2usdceth).read() != hackedValue);
@@ -236,10 +219,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(matic).read() != hackedValue);
         assertTrue(OsmLike(wsteth).read() != hackedValue);
 
-        assertTrue(OsmLike(bat).read() != hackedValue);
-        assertTrue(OsmLike(zrx).read() != hackedValue);
-        assertTrue(OsmLike(lrc).read() != hackedValue);
-        assertTrue(OsmLike(univ2linketh).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
 
@@ -249,11 +228,9 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(eth).read(), hackedValue);
         assertEq(OsmLike(btc).read(), hackedValue);
         assertEq(OsmLike(mana).read(), hackedValue);
-        assertEq(OsmLike(comp).read(), hackedValue);
         assertEq(OsmLike(link).read(), hackedValue);
         assertEq(OsmLike(yfi).read(), hackedValue);
         assertEq(OsmLike(uni).read(), hackedValue);
-        assertEq(OsmLike(aave).read(), hackedValue);
         assertEq(OsmLike(univ2daieth).read(), hackedValue);
         assertEq(OsmLike(univ2wbtceth).read(), hackedValue);
         assertEq(OsmLike(univ2usdceth).read(), hackedValue);
@@ -264,11 +241,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(wsteth).read(), hackedValue);
 
         // Daily OSM's are not updated after one hour
-        assertTrue(OsmLike(bat).read() != hackedValue);
-        assertTrue(OsmLike(zrx).read() != hackedValue);
-        assertTrue(OsmLike(lrc).read() != hackedValue);
-        assertTrue(OsmLike(bal).read() != hackedValue);
-        assertTrue(OsmLike(univ2linketh).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
 
@@ -286,9 +258,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         (, mat) = SpotLike(spotter).ilks("MANA-A");
         (,, spot,,) = VatLike(vat).ilks("MANA-A");
         assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("COMP-A");
-        (,, spot,,) = VatLike(vat).ilks("COMP-A");
-        assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("LINK-A");
         (,, spot,,) = VatLike(vat).ilks("LINK-A");
         assertEq(spot, _rdiv(value, mat));
@@ -303,9 +272,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("UNI-A");
         (,, spot,,) = VatLike(vat).ilks("UNI-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("AAVE-A");
-        (,, spot,,) = VatLike(vat).ilks("AAVE-A");
         assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("UNIV2DAIETH-A");
         (,, spot,,) = VatLike(vat).ilks("UNIV2DAIETH-A");
@@ -342,21 +308,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(spot, _rdiv(value, mat));
 
         // These collateral types should not be updated after 1 hour
-        (, mat) = SpotLike(spotter).ilks("BAT-A");
-        (,, spot,,) = VatLike(vat).ilks("BAT-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("ZRX-A");
-        (,, spot,,) = VatLike(vat).ilks("ZRX-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("LRC-A");
-        (,, spot,,) = VatLike(vat).ilks("LRC-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("BAL-A");
-        (,, spot,,) = VatLike(vat).ilks("BAL-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("UNIV2LINKETH-A");
-        (,, spot,,) = VatLike(vat).ilks("UNIV2LINKETH-A");
-        assertTrue(spot != _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
         (,, spot,,) = VatLike(vat).ilks("GUNIV3DAIUSDC1-A");
         assertTrue(spot != _rdiv(value, mat));
@@ -370,29 +321,10 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         megaPoker.poke();
         assertEq(megaPoker.last(), block.timestamp);
 
-        assertEq(OsmLike(bat).read(), hackedValue);
-        assertEq(OsmLike(zrx).read(), hackedValue);
-        assertEq(OsmLike(lrc).read(), hackedValue);
-        assertEq(OsmLike(bal).read(), hackedValue);
         assertEq(OsmLike(guniv3daiusdc1).read(), hackedValue);
         assertEq(OsmLike(guniv3daiusdc2).read(), hackedValue);
 
 
-        (, mat) = SpotLike(spotter).ilks("BAT-A");
-        (,, spot,,) = VatLike(vat).ilks("BAT-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("ZRX-A");
-        (,, spot,,) = VatLike(vat).ilks("ZRX-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("LRC-A");
-        (,, spot,,) = VatLike(vat).ilks("LRC-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("BAL-A");
-        (,, spot,,) = VatLike(vat).ilks("BAL-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("UNIV2LINKETH-A");
-        (,, spot,,) = VatLike(vat).ilks("UNIV2LINKETH-A");
-        assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
         (,, spot,,) = VatLike(vat).ilks("GUNIV3DAIUSDC1-A");
         assertEq(spot, _rdiv(value, mat));


### PR DESCRIPTION
Working off of the latest list of offboarded collateral types.

* BAL-A
* COMP-A
* AAVE-A
* BAT-A
* LRC-A
* ZRX-A
* UNIV2AAVEETH-A
* UNIV2LINKETH-A
* USDT
* KNC-A

A couple of these had already been removed.

Looking for a signoff from OCU as well.