### PR TITLE
chore: remove offboarded collaterals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker current Mainnet Address: [0x7818c2084140D7405F47Cf4159774C559142D516](https://etherscan.io/address/0x7818c2084140D7405F47Cf4159774C559142D516#code)
+MegaPoker current Mainnet Address: [0x021CfECaF7027d736f796f8FC62c6513e04ca0D4](https://etherscan.io/address/0x021CfECaF7027d736f796f8FC62c6513e04ca0D4#code)
 
 # OmegaPoker
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker current Mainnet Address: [0x37bA4427F664557e92493C5858A81C9B90fC09d6](https://etherscan.io/address/0x37bA4427F664557e92493C5858A81C9B90fC09d6#code)
+MegaPoker current Mainnet Address: [0x7818c2084140D7405F47Cf4159774C559142D516](https://etherscan.io/address/0x7818c2084140D7405F47Cf4159774C559142D516#code)
 
 # OmegaPoker
 

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -22,7 +22,6 @@ contract PokingAddresses {
     // OSMs
     address constant btc            = 0xf185d0682d50819263941e5f4EacC763CC5C6C42;
     address constant eth            = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763;
-    address constant reth           = 0xeE7F0b350aA119b3d05DC733a4621a81972f7D47;
     address constant wsteth         = 0xFe7a2aC0B945f12089aEEB6eCebf4F384D9f043F;
     address constant mkr            = 0x4F94e33D0D74CfF5Ca0D3a66F1A650628551C56b;
 
@@ -45,7 +44,6 @@ contract MegaPoker is PokingAddresses {
         // poke() = 0x18178358
         (ok,) = btc.call(abi.encodeWithSelector(0x18178358));
         (ok,) = eth.call(abi.encodeWithSelector(0x18178358));
-        (ok,) = reth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = wsteth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = mkr.call(abi.encodeWithSelector(0x18178358));
 
@@ -53,7 +51,6 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-C")));
-        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("RETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WBTC-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WBTC-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WBTC-C")));

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -25,7 +25,6 @@ contract PokingAddresses {
     address constant wsteth         = 0xFe7a2aC0B945f12089aEEB6eCebf4F384D9f043F;
     address constant mkr            = 0x4F94e33D0D74CfF5Ca0D3a66F1A650628551C56b;
 
-    address constant crvv1ethsteth  = 0xEa508F82728927454bd3ce853171b0e2705880D4;
     address constant guniv3daiusdc1 = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
     address constant guniv3daiusdc2 = 0xcCBa43231aC6eceBd1278B90c3a44711a00F4e93;
     address constant univ2daiusdc   = 0x25D03C2C928ADE19ff9f4FFECc07d991d0df054B;
@@ -61,8 +60,6 @@ contract MegaPoker is PokingAddresses {
         // Daily pokes, i.e. reduced cost pokes
         if (last <= block.timestamp - 1 days) {
             // Poke
-            (ok,) = crvv1ethsteth.call(abi.encodeWithSelector(0x18178358));
-
             // The GUINIV3DAIUSDCX Oracles are very expensive to poke, and the
             // price should not change frequently, so they are getting poked
             // only once a day.
@@ -72,7 +69,6 @@ contract MegaPoker is PokingAddresses {
             (ok,) = univ2daiusdc.call(abi.encodeWithSelector(0x18178358));
 
             // Spotter pokes
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("CRVV1ETHSTETH-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC2-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2DAIUSDC-A")));

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -275,13 +275,11 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         (, mat) = SpotLike(spotter).ilks("WBTC-C");
         (,, spot,,) = vat.ilks("WBTC-C");
         assertEq(spot, _rdiv(value, mat));
-        assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("LSE-MKR-A");
         (,, spot,,) = vat.ilks("LSE-MKR-A");
         assertEq(spot, _rdiv(value, mat));
 
         // These collateral types should not be updated after 1 hour
-        assertTrue(spot != _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
         (,, spot,,) = vat.ilks("GUNIV3DAIUSDC1-A");
         assertTrue(spot != _rdiv(value, mat));

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -169,7 +169,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
 
         // Whitelisting tester address
         hevm.store(btc, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(crvv1ethsteth, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(eth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(guniv3daiusdc1, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(guniv3daiusdc2, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
@@ -217,7 +216,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         // Hacking nxt price to 0x123 (and making it valid)
         bytes32 hackedValue = 0x0000000000000000000000000000000100000000000000000000000000000123;
         hevm.store(btc, bytes32(uint256(4)), hackedValue);
-        hevm.store(crvv1ethsteth, bytes32(uint256(4)), hackedValue);
         hevm.store(eth, bytes32(uint256(4)), hackedValue);
         hevm.store(guniv3daiusdc1, bytes32(uint256(4)), hackedValue);
         hevm.store(guniv3daiusdc2, bytes32(uint256(4)), hackedValue);
@@ -233,7 +231,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(wsteth).read() != hackedValue);
         assertTrue(OsmLike(mkr).read() != hackedValue);
 
-        assertTrue(OsmLike(crvv1ethsteth).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
         assertTrue(OsmLike(univ2daiusdc).read() != hackedValue);
@@ -247,7 +244,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(mkr).read(), hackedValue);
 
         // Daily OSM's are not updated after one hour
-        assertTrue(OsmLike(crvv1ethsteth).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
         assertTrue(OsmLike(univ2daiusdc).read() != hackedValue);
@@ -285,8 +281,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(spot, _rdiv(value, mat));
 
         // These collateral types should not be updated after 1 hour
-        (, mat) = SpotLike(spotter).ilks("CRVV1ETHSTETH-A");
-        (,, spot,,) = vat.ilks("CRVV1ETHSTETH-A");
         assertTrue(spot != _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
         (,, spot,,) = vat.ilks("GUNIV3DAIUSDC1-A");

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -173,7 +173,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         hevm.store(eth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(guniv3daiusdc1, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(guniv3daiusdc2, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
-        hevm.store(reth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(univ2daiusdc, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(wsteth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(mkr, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
@@ -222,7 +221,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         hevm.store(eth, bytes32(uint256(4)), hackedValue);
         hevm.store(guniv3daiusdc1, bytes32(uint256(4)), hackedValue);
         hevm.store(guniv3daiusdc2, bytes32(uint256(4)), hackedValue);
-        hevm.store(reth, bytes32(uint256(4)), hackedValue);
         hevm.store(univ2daiusdc, bytes32(uint256(4)), hackedValue);
         hevm.store(wsteth, bytes32(uint256(4)), hackedValue);
         hevm.store(mkr, bytes32(uint256(4)), hackedValue);
@@ -232,7 +230,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
 
         assertTrue(OsmLike(btc).read() != hackedValue);
         assertTrue(OsmLike(eth).read() != hackedValue);
-        assertTrue(OsmLike(reth).read() != hackedValue);
         assertTrue(OsmLike(wsteth).read() != hackedValue);
         assertTrue(OsmLike(mkr).read() != hackedValue);
 
@@ -246,7 +243,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
 
         assertEq(OsmLike(btc).read(), hackedValue);
         assertEq(OsmLike(eth).read(), hackedValue);
-        assertEq(OsmLike(reth).read(), hackedValue);
         assertEq(OsmLike(wsteth).read(), hackedValue);
         assertEq(OsmLike(mkr).read(), hackedValue);
 
@@ -283,8 +279,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         (, mat) = SpotLike(spotter).ilks("WBTC-C");
         (,, spot,,) = vat.ilks("WBTC-C");
         assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("RETH-A");
-        (,, spot,,) = vat.ilks("RETH-A");
         assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("LSE-MKR-A");
         (,, spot,,) = vat.ilks("LSE-MKR-A");


### PR DESCRIPTION
This PR removes offboarded collaterals
- `RETH-A`
- `CRVV1ETHSTETH-A `

Both collaterals have `Art` and `line` set to 0 (checked [here](https://etherscan.io/address/0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b#readContract#F6))