### PR TITLE
Add new Sky OSM and LSEV2-SKY-A ilk

### DIFF
--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -24,6 +24,7 @@ contract PokingAddresses {
     address constant eth            = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763;
     address constant wsteth         = 0xFe7a2aC0B945f12089aEEB6eCebf4F384D9f043F;
     address constant mkr            = 0x4F94e33D0D74CfF5Ca0D3a66F1A650628551C56b;
+    address constant sky            = 0x511485bBd96e7e3a056a8D1b84C5071071C52D6F;
 
     address constant guniv3daiusdc1 = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
     address constant guniv3daiusdc2 = 0xcCBa43231aC6eceBd1278B90c3a44711a00F4e93;
@@ -45,6 +46,7 @@ contract MegaPoker is PokingAddresses {
         (ok,) = eth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = wsteth.call(abi.encodeWithSelector(0x18178358));
         (ok,) = mkr.call(abi.encodeWithSelector(0x18178358));
+        (ok,) = sky.call(abi.encodeWithSelector(0x18178358));
 
         // poke(bytes32) = 0x1504460f
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("ETH-A")));
@@ -56,6 +58,7 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LSE-MKR-A")));
+        (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LSEV2-SKY-A")));
 
         // Daily pokes, i.e. reduced cost pokes
         if (last <= block.timestamp - 1 days) {

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -61,17 +61,16 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LSEV2-SKY-A")));
 
         // Daily pokes, i.e. reduced cost pokes
+        // The GUINIV3DAIUSDCX Oracles are very expensive to poke, and the
+        // price should not change frequently, so they are getting poked
+        // only once a day.
         if (last <= block.timestamp - 1 days) {
-            // Poke
-            // The GUINIV3DAIUSDCX Oracles are very expensive to poke, and the
-            // price should not change frequently, so they are getting poked
-            // only once a day.
+            // poke() = 0x18178358
             (ok,) = guniv3daiusdc1.call(abi.encodeWithSelector(0x18178358));
             (ok,) = guniv3daiusdc2.call(abi.encodeWithSelector(0x18178358));
-
             (ok,) = univ2daiusdc.call(abi.encodeWithSelector(0x18178358));
 
-            // Spotter pokes
+            // poke(bytes32) = 0x1504460f
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC2-A")));
             (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2DAIUSDC-A")));

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -175,33 +175,33 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         hevm.store(univ2daiusdc, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(wsteth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(mkr, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
+        hevm.store(sky, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
 
         // Initializing any uninitialized OSM and ilks
         uint256 spot;
         bool haz;
 
-        // MKR
+        // Sky
         {
-            // Authorize the MegaPoker in MKR OSM
-            hevm.store(mkr, keccak256(abi.encode(address(megaPoker), uint256(5))), bytes32(uint256(1)));
-            // Authorize the Spotter in MKR OSM
-            hevm.store(mkr, keccak256(abi.encode(address(spotter), uint256(5))), bytes32(uint256(1)));
+            // Authorize the MegaPoker in OSM
+            hevm.store(sky, keccak256(abi.encode(address(megaPoker), uint256(5))), bytes32(uint256(1)));
+            // Authorize the Spotter in OSM
+            hevm.store(sky, keccak256(abi.encode(address(spotter), uint256(5))), bytes32(uint256(1)));
 
-            (,, spot,,) = vat.ilks("LSE-MKR-A");
+            (,, spot,,) = vat.ilks("LSEV2-SKY-A");
             if (spot == 0) {
-                vat.init("LSE-MKR-A");
-                SpotLike(spotter).file("LSE-MKR-A", "pip", mkr);
-                SpotLike(spotter).file("LSE-MKR-A", "mat", 150 * RAY / 100);
-
+                vat.init("LSEV2-SKY-A");
+                SpotLike(spotter).file("LSEV2-SKY-A", "pip", sky);
+                SpotLike(spotter).file("LSEV2-SKY-A", "mat", 150 * RAY / 100);
             }
 
-            (, haz) = OsmLike(mkr).peek();
+            (, haz) = OsmLike(sky).peek();
             if (!haz) {
                 // Whitelist OSM in Median
-                hevm.store(OsmLike(mkr).src(), keccak256(abi.encode(mkr, uint256(4))), bytes32(uint256(1)));
-                OsmLike(mkr).poke();
+                hevm.store(OsmLike(sky).src(), keccak256(abi.encode(sky, uint256(4))), bytes32(uint256(1)));
+                OsmLike(sky).poke();
                 hevm.warp(block.timestamp + 1 hours);
-                OsmLike(mkr).poke();
+                OsmLike(sky).poke();
             }
         }
 
@@ -222,6 +222,7 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         hevm.store(univ2daiusdc, bytes32(uint256(4)), hackedValue);
         hevm.store(wsteth, bytes32(uint256(4)), hackedValue);
         hevm.store(mkr, bytes32(uint256(4)), hackedValue);
+        hevm.store(sky, bytes32(uint256(4)), hackedValue);
 
         // 0x123
         hackedValue = 0x0000000000000000000000000000000000000000000000000000000000000123;
@@ -230,6 +231,7 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(eth).read() != hackedValue);
         assertTrue(OsmLike(wsteth).read() != hackedValue);
         assertTrue(OsmLike(mkr).read() != hackedValue);
+        assertTrue(OsmLike(sky).read() != hackedValue);
 
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
         assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
@@ -242,6 +244,7 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(eth).read(), hackedValue);
         assertEq(OsmLike(wsteth).read(), hackedValue);
         assertEq(OsmLike(mkr).read(), hackedValue);
+        assertEq(OsmLike(sky).read(), hackedValue);
 
         // Daily OSM's are not updated after one hour
         assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
@@ -277,6 +280,9 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("LSE-MKR-A");
         (,, spot,,) = vat.ilks("LSE-MKR-A");
+        assertEq(spot, _rdiv(value, mat));
+        (, mat) = SpotLike(spotter).ilks("LSEV2-SKY-A");
+        (,, spot,,) = vat.ilks("LSEV2-SKY-A");
         assertEq(spot, _rdiv(value, mat));
 
         // These collateral types should not be updated after 1 hour


### PR DESCRIPTION
This PR adds new OSM and a new ilk planned to be onboarded via the `2025-05-15` spell.