### PR TITLE
Offboard GUNIV3 and UNIV2 tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker current Mainnet Address: [0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999](https://etherscan.io/address/0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999#code)
-**_TODO:_** Deploy the new MegaPoker contract and update its Mainnet Address.
+MegaPoker current Mainnet Address: [0xE1d2b2840c2374C0b02E1C0c84Da2026F30f3614](https://etherscan.io/address/0xE1d2b2840c2374C0b02E1C0c84Da2026F30f3614#code)
 
 # OmegaPoker
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker current Mainnet Address: [0xE1d2b2840c2374C0b02E1C0c84Da2026F30f3614](https://etherscan.io/address/0xE1d2b2840c2374C0b02E1C0c84Da2026F30f3614#code)
+MegaPoker current Mainnet Address: [0x1b3359D8e087c02D56b22765Ca0C53C9f3f64F5e](https://etherscan.io/address/0x1b3359D8e087c02D56b22765Ca0C53C9f3f64F5e#code)
 
 # OmegaPoker
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Optimized Smart Contract to Poke (`poke`).
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
 MegaPoker current Mainnet Address: [0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999](https://etherscan.io/address/0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999#code)
+**_TODO:_** Deploy the new MegaPoker contract and update its Mainnet Address.
 
 # OmegaPoker
 

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -30,9 +30,6 @@ contract PokingAddresses {
 }
 
 contract MegaPoker is PokingAddresses {
-
-    uint256 public last;
-
     function poke() external {
         bool ok;
 
@@ -52,6 +49,5 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-A")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LSEV2-SKY-A")));
-
     }
 }

--- a/src/MegaPoker.sol
+++ b/src/MegaPoker.sol
@@ -25,10 +25,6 @@ contract PokingAddresses {
     address constant wsteth         = 0xFe7a2aC0B945f12089aEEB6eCebf4F384D9f043F;
     address constant sky            = 0x511485bBd96e7e3a056a8D1b84C5071071C52D6F;
 
-    address constant guniv3daiusdc1 = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
-    address constant guniv3daiusdc2 = 0xcCBa43231aC6eceBd1278B90c3a44711a00F4e93;
-    address constant univ2daiusdc   = 0x25D03C2C928ADE19ff9f4FFECc07d991d0df054B;
-
     // Spotter
     address constant spotter        = 0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3;
 }
@@ -57,22 +53,5 @@ contract MegaPoker is PokingAddresses {
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("WSTETH-B")));
         (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("LSEV2-SKY-A")));
 
-        // Daily pokes, i.e. reduced cost pokes
-        if (last <= block.timestamp - 1 days) {
-            // Poke
-            // The GUINIV3DAIUSDCX Oracles are very expensive to poke, and the
-            // price should not change frequently, so they are getting poked
-            // only once a day.
-            (ok,) = guniv3daiusdc1.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = guniv3daiusdc2.call(abi.encodeWithSelector(0x18178358));
-            (ok,) = univ2daiusdc.call(abi.encodeWithSelector(0x18178358));
-
-            // Spotter pokes
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC1-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("GUNIV3DAIUSDC2-A")));
-            (ok,) = spotter.call(abi.encodeWithSelector(0x1504460f, bytes32("UNIV2DAIUSDC-A")));
-
-            last = block.timestamp;
-        }
     }
 }

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -205,10 +205,8 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         // To update osms without any value yet
         hevm.warp(block.timestamp + 1 hours);
         megaPoker.poke();
-        assertEq(megaPoker.last(), block.timestamp);
         hevm.warp(block.timestamp + 1 hours);
         megaPoker.poke();
-        assertEq(megaPoker.last(), block.timestamp - 1 hours);
 
         // Hacking nxt price to 0x123 (and making it valid)
         bytes32 hackedValue = 0x0000000000000000000000000000000100000000000000000000000000000123;

--- a/src/MegaPoker.t.sol
+++ b/src/MegaPoker.t.sol
@@ -170,9 +170,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         // Whitelisting tester address
         hevm.store(btc, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(eth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
-        hevm.store(guniv3daiusdc1, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
-        hevm.store(guniv3daiusdc2, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
-        hevm.store(univ2daiusdc, keccak256(abi.encode(address(this), uint256(2))), bytes32(uint256(1)));
         hevm.store(wsteth, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
         hevm.store(sky, keccak256(abi.encode(address(this), uint256(5))), bytes32(uint256(1)));
 
@@ -217,9 +214,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         bytes32 hackedValue = 0x0000000000000000000000000000000100000000000000000000000000000123;
         hevm.store(btc, bytes32(uint256(4)), hackedValue);
         hevm.store(eth, bytes32(uint256(4)), hackedValue);
-        hevm.store(guniv3daiusdc1, bytes32(uint256(4)), hackedValue);
-        hevm.store(guniv3daiusdc2, bytes32(uint256(4)), hackedValue);
-        hevm.store(univ2daiusdc, bytes32(uint256(4)), hackedValue);
         hevm.store(wsteth, bytes32(uint256(4)), hackedValue);
         hevm.store(sky, bytes32(uint256(4)), hackedValue);
 
@@ -231,10 +225,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertTrue(OsmLike(wsteth).read() != hackedValue);
         assertTrue(OsmLike(sky).read() != hackedValue);
 
-        assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
-        assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
-        assertTrue(OsmLike(univ2daiusdc).read() != hackedValue);
-
         hevm.warp(block.timestamp + 2 hours);
         megaPoker.poke();
 
@@ -242,11 +232,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(OsmLike(eth).read(), hackedValue);
         assertEq(OsmLike(wsteth).read(), hackedValue);
         assertEq(OsmLike(sky).read(), hackedValue);
-
-        // Daily OSM's are not updated after one hour
-        assertTrue(OsmLike(guniv3daiusdc1).read() != hackedValue);
-        assertTrue(OsmLike(guniv3daiusdc2).read() != hackedValue);
-        assertTrue(OsmLike(univ2daiusdc).read() != hackedValue);
 
         uint256 mat;
         uint256 value = _rdiv(_mul(uint256(hackedValue), 10 ** 9), SpotLike(spotter).par());
@@ -277,32 +262,6 @@ contract MegaPokerTest is DSTest, PokingAddresses {
         assertEq(spot, _rdiv(value, mat));
         (, mat) = SpotLike(spotter).ilks("LSEV2-SKY-A");
         (,, spot,,) = vat.ilks("LSEV2-SKY-A");
-        assertEq(spot, _rdiv(value, mat));
-
-        // These collateral types should not be updated after 1 hour
-        (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
-        (,, spot,,) = vat.ilks("GUNIV3DAIUSDC1-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC2-A");
-        (,, spot,,) = vat.ilks("GUNIV3DAIUSDC2-A");
-        assertTrue(spot != _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("UNIV2DAIUSDC-A");
-        (,, spot,,) = vat.ilks("UNIV2DAIUSDC-A");
-        assertTrue(spot != _rdiv(value, mat));
-
-        // Daily OSM's are eligible 24 hours after first poked
-        hevm.warp(megaPoker.last() + 24 hours);
-        megaPoker.poke();
-        assertEq(megaPoker.last(), block.timestamp);
-
-        assertEq(OsmLike(guniv3daiusdc1).read(), hackedValue);
-        assertEq(OsmLike(guniv3daiusdc2).read(), hackedValue);
-
-        (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC1-A");
-        (,, spot,,) = vat.ilks("GUNIV3DAIUSDC1-A");
-        assertEq(spot, _rdiv(value, mat));
-        (, mat) = SpotLike(spotter).ilks("GUNIV3DAIUSDC2-A");
-        (,, spot,,) = vat.ilks("GUNIV3DAIUSDC2-A");
         assertEq(spot, _rdiv(value, mat));
     }
 


### PR DESCRIPTION
This PR removes `UNIV2DAIUSDC-A`, `GUNIV3DAIUSDC1-A` and `GUNIV3DAIUSDC2-A` from the MegaPoker, as `PIP_UNIV2DAIUSDC` was offboarded at [2025-08-21 spell](https://github.com/sky-ecosystem/spells-mainnet/pull/485) and `PIP_GUNIV3DAIUSDC1` and `PIP_GUNIV3DAIUSDC2` were both offboarded at [2026-01-15 spell](https://github.com/sky-ecosystem/spells-mainnet/pull/505)